### PR TITLE
prevent second callback execution on error

### DIFF
--- a/lm-sensors.js
+++ b/lm-sensors.js
@@ -92,7 +92,7 @@ var parser = function (sensors_output) {
 module.exports = {
     sensors: function (done) {
         var sensors = childProcess.exec('sensors', function (error, stdout, stderr) {
-           if (error) done(null, error);
+           if (error) return done(null, error);
            done(parser(stdout.toString()), null);
         });
     },


### PR DESCRIPTION
when an error occurs, `done()` was called twice