### PR TITLE
sensors: Only list devices specified

### DIFF
--- a/lm-sensors.js
+++ b/lm-sensors.js
@@ -90,8 +90,10 @@ var parser = function (sensors_output) {
 // parser(output);
 
 module.exports = {
-    sensors: function (done) {
-        var sensors = childProcess.exec('sensors', function (error, stdout, stderr) {
+    sensors: function (done, devices = []) {
+        const commandElements = ['sensors'].concat(devices);
+        const command = commandElements.join(" ");
+        const sensors = childProcess.exec(command, function (error, stdout, stderr) {
            if (error) return done(null, error);
            done(parser(stdout.toString()), null);
         });


### PR DESCRIPTION
Allows a client of the library to only specify specific devices it is interested in.  I found under certain conditions the underlying drivers might become unresponsive leading to long waits.  This allows the software to query for only the devices it is interested in.  such as `["coretemp-isa-0000", "coretemp-isa-0001"]`.